### PR TITLE
add ability to use emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@fortawesome/fontawesome-free": "5.14.0",
     "axios": "0.20.0",
     "bootstrap": "4.5.2",
+    "emojis": "^1.0.10",
     "jquery": "3.5.1",
     "moment": "^2.27.0",
     "popper.js": "1.16.1"

--- a/src/javascripts/components/addMessage.js
+++ b/src/javascripts/components/addMessage.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import emojis from 'emojis';
 import Data from '../helpers/data/messageData';
 import Print from './displayMessages';
 
@@ -12,7 +13,7 @@ const messageAction = () => {
       id: `message${Data.getMessages().length + 1}`,
       user: `${radioSelection}`,
       image: `${imageSelection}`,
-      message: $('#message-input').val(),
+      message: emojis.unicode($('#message-input').val()),
       timestamp: moment().format('MMMM Do YYYY, h:mm a')
     };
     Data.getMessages().push(newMessage);


### PR DESCRIPTION
## Description
- Add ability to type in the unicode value for emojis and have the emoji displayed within the message.

## Related Issue
- #10 

## Motivation and Context
- This change lets a user use emoji's in their messages.

## How Can This Be Tested?
```git fetch origin emoji```
run npm install to install the package "emojis" that is handling parsing the unicode into visible emojis.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)