### PR TITLE
large text checkbox toggles between large font and regular font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,9 +20,13 @@
     <div class="error" id="error"></div>
   </div>
   <div class="container row">
-  <input type="checkbox" class="m-2" id="darkMode">
-  <h5 class="ml-1">Dark Mode</h5>
-</div>
+    <input type="checkbox" class="m-2" id="darkMode">
+    <h3 class="ml-1">Dark Mode</h3>
+  </div>
+  <div class="container row">
+    <input type="checkbox" class="m-2" id="largeText">
+    <h3 class="ml-1">Large Text</h3>
+  </div>
   <div class="container">
     <div class="row">
       <div id="settings-container">

--- a/src/javascripts/components/darkMode.js
+++ b/src/javascripts/components/darkMode.js
@@ -1,7 +1,0 @@
-const darkMode = () => {
-  $('#darkMode').on('click', () => {
-    document.body.classList.toggle('dark-mode');
-  });
-};
-
-export default { darkMode };

--- a/src/javascripts/components/modes.js
+++ b/src/javascripts/components/modes.js
@@ -1,0 +1,13 @@
+const darkMode = () => {
+  $('#darkMode').on('click', () => {
+    document.body.classList.toggle('dark-mode');
+  });
+};
+
+const largeText = () => {
+  $('#largeText').on('click', () => {
+    document.body.classList.toggle('large-text');
+  });
+};
+
+export default { darkMode, largeText };

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -2,14 +2,15 @@ import '../styles/main.scss';
 import Display from './components/displayMessages';
 import Button from './components/buttonActions';
 import Message from './components/addMessage';
-import Dark from './components/darkMode';
+import Modes from './components/modes';
 import Users from './components/multipleUsers';
 
 const init = () => {
   Message.addMessage();
   Button.clearButton();
   Display.printMessages();
-  Dark.darkMode();
+  Modes.darkMode();
+  Modes.largeText();
   Users.userSelection();
 };
 

--- a/src/styles/components/_modes.scss
+++ b/src/styles/components/_modes.scss
@@ -2,3 +2,12 @@
     background-color: black;
     color: white;
   }
+
+.large-text {
+  font-size: 1.5em;
+  h5{font-size: 1.6em;}
+  h4{font-size: 1.7em;}
+  .timestamp {
+    font-size: .9em;
+  }
+}


### PR DESCRIPTION
## Description
Added a checkbox similar to dark mode to change font size to much larger.

## Related Issue
Resolves #16 

## Motivation and Context
This allows users to choose the text size on the page, making the page more accessible to users with visual impairments.

## How Can This Be Tested?
```git fetch origin large-text```

## Screenshots (if appropriate):
![Screen Shot 2020-09-12 at 9 59 17 AM](https://user-images.githubusercontent.com/63985074/92998299-a36d7c80-f4de-11ea-9028-6aaae21ac6c6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)