### PR TITLE
Editing and Deleting Bot Messages Bug Fix

### DIFF
--- a/src/javascripts/components/addMessage.js
+++ b/src/javascripts/components/addMessage.js
@@ -5,6 +5,8 @@ import Print from './displayMessages';
 import Bot from '../helpers/data/botData';
 
 const messageAction = () => {
+  const lastIndex = Message.getMessages().length - 1;
+  let idNumber = Message.getMessages().length === 0 ? 1 : Number(Message.getMessages()[lastIndex].id) + 1;
   const messageValue = $('#message-input').val();
   if (messageValue === '') {
     $('#error').html('<p>Please enter a message</p>');
@@ -17,7 +19,7 @@ const messageAction = () => {
         'input[name=character]:checked'
       ).id;
       const newMessage = {
-        id: `message${Message.getMessages().length + 1}`,
+        id: idNumber.toString(),
         user: `${radioSelection}`,
         image: `${imageSelection}`,
         message: emojis.unicode(messageValue),
@@ -43,7 +45,7 @@ const messageAction = () => {
         )
       ) {
         const botMessage = {
-          id: `message${Message.getMessages().length + 1 + i}`,
+          id: (idNumber + 1).toString(),
           user: `${Bot.bots[i].user}`,
           image: `${Bot.bots[i].image}`,
           message: `${
@@ -53,6 +55,7 @@ const messageAction = () => {
           }`,
           timestamp: moment().format('MMMM Do YYYY, h:mm a'),
         };
+        idNumber += 1;
         setTimeout(() => {
           Message.getMessages().push(botMessage);
           Print.printMessages();

--- a/src/javascripts/helpers/data/messageData.js
+++ b/src/javascripts/helpers/data/messageData.js
@@ -6,28 +6,28 @@ import Schroeder from '../../../assets/images/Schroeder.jpg';
 
 const messageArray = [
   {
-    id: 'message1',
+    id: '1',
     user: 'Charlie Brown',
     image: `${Chuck}`,
     message: 'Good grief...',
     timestamp: 'October 2, 1950, 6:15 am',
   },
   {
-    id: 'message2',
+    id: '2',
     user: 'Snoopy',
     image: `${Snoopy}`,
     message: 'LOL',
     timestamp: 'October 4, 1950, 12:02 am',
   },
   {
-    id: 'message3',
+    id: '3',
     user: 'Schroeder',
     image: `${Schroeder}`,
     message: "Christmastime Is Here? But it's September!",
     timestamp: 'May 30, 1951, 8:48 pm',
   },
   {
-    id: 'message4',
+    id: '4',
     user: 'Lucy',
     image: `${Lucy}`,
     message:
@@ -35,7 +35,7 @@ const messageArray = [
     timestamp: 'March 3, 1952, 10:11 pm',
   },
   {
-    id: 'message5',
+    id: '5',
     user: 'Woodstock',
     image: `${Woodstock}`,
     message: '*Chittering noises*',


### PR DESCRIPTION
## Description
Fixed bug that was making messages unable to be deleted or edited after multiple bot replies or after some messages were deleted.

## Related Issue
#46 

## Motivation and Context
Solves the problem of delete and edit buttons not working on certain messages after a multiple-bot response or after some messages are deleted. Fixed by updating message IDs and how message IDs are created.

## How Can This Be Tested?
`git fetch origin new-bugs`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)