### PR TITLE
updated dark mode to change container color and text color

### DIFF
--- a/src/styles/components/_modes.scss
+++ b/src/styles/components/_modes.scss
@@ -1,6 +1,25 @@
 .dark-mode {
     background-color: black;
     color: white;
+    .timestamp {
+      color: lightgray;
+    }
+    %container {
+      background-color: #2C74A0;
+    }
+    .message-content {
+      background-color: #333333;
+      color: white;
+    }
+    #settings-container {
+      color: white;
+    }
+    .edit {
+      color: white;
+    }
+    .close {
+      color: white;
+    }
   }
 
 .large-text {


### PR DESCRIPTION
## Description
Updated dark mode style to change the background color of the containers to dark and fonts/buttons to light.

## Related Issue
None

## Motivation and Context
Meets the requirements for the dark mode issue ticket.

## How Can This Be Tested?
```git fetch origin readme```

## Screenshots (if appropriate):
![Screen Shot 2020-09-15 at 12 35 18 PM](https://user-images.githubusercontent.com/63985074/93244922-16c9f500-f750-11ea-9bc1-fbfb8d6012da.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)